### PR TITLE
AOC-47 | fix code coverage reports fail to upload

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,5 +5,3 @@ Ticket [4](https://trello.com/c/5HvOiqQ9/4-hill-climbing-algorithm)
 **Summary**
 
 Add a description of the changes and the related issues. Please also include relevant motivation and context. List any dependencies that are required for this change.
-
-

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -32,9 +32,12 @@ jobs:
         run: yarn install
       - name: generate coverage report
         run: yarn coverage
-        continue-on-error: true
+        continue-on-error: false
       - name: upload coverage report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        continue-on-error: false
         with:
           flags: unittests
 


### PR DESCRIPTION
## Title

Ticket [47](https://trello.com/c/S15DrY8Q/47-code-coverage-upload-fails)

**Summary**

The code coverage report was failing to be uploaded, therefore the tests were not updated. In order to haver an up to date code coverage, there was a need to fix the current issue.


